### PR TITLE
Modify IPU JAX notebooks to be compatible with Paperspace Gradient.

### DIFF
--- a/.gradient/available_ipus.py
+++ b/.gradient/available_ipus.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2022 Graphcore Ltd. All rights reserved.
+import subprocess
+import json
+
+j = subprocess.check_output(['gc-monitor', '-j'])
+data = json.loads(j)
+num_ipuMs = len(data["cards"])
+num_ipus = 4 * num_ipuMs
+
+# to be captured as a variable in the bash script that calls this python script
+print(num_ipus)

--- a/README.md
+++ b/README.md
@@ -54,9 +54,12 @@ output = ipu_function(data)
 print(output, output.device())
 ```
 
-**Additional JAX on IPU examples:**
+**JAX on IPU Paperspace notebooks:**
 
-* [JAX on IPU quickstart notebook](ipu/examples/ipu_quickstart.ipynb);
+* [JAX on IPU quickstart](ipu/examples/jax_ipu_quickstart.ipynb) [![Run on Gradient](https://assets.paperspace.io/img/gradient-badge.svg)](https://console.paperspace.com/github/graphcore-research/jax-experimental?container=graphcore%2Fpytorch-jupyter%3A3.1.0-ubuntu-20.04&machine=Free-IPU-POD4&file=%2Fipu%2Fexamples%2Fjax_ipu_quickstart.ipynb)
+
+**Additional JAX on IPU Python examples:**
+
 * [MNIST classifier training on IPU](ipu/examples/mnist_classifier.py)
 * [MNIST classifier training on IPU, with infeeds](ipu/examples/mnist_classifier_with_infeed.py)
 

--- a/ipu/examples/jax_ipu_quickstart.ipynb
+++ b/ipu/examples/jax_ipu_quickstart.ipynb
@@ -1,58 +1,56 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Quickstart: running Jax on IPU"
+    "# Quickstart: running JAX on IPU"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install experimental JAX for IPUs\n",
+    "import sys\n",
+    "!{sys.executable} -m pip uninstall -y jax jaxlib\n",
+    "!{sys.executable} -m pip install https://github.com/graphcore-research/jax-mk2-experimental/releases/latest/download/jaxlib-0.3.15-cp38-none-manylinux2014_x86_64.whl\n",
+    "!{sys.executable} -m pip install https://github.com/graphcore-research/jax-mk2-experimental/releases/latest/download/jax-0.3.16-py3-none-any.whl"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "from jax.config import config\n",
-    "# Using IPU model emulator. Comment to use IPU hardware.\n",
-    "config.FLAGS.jax_ipu_use_model = True\n",
-    "config.FLAGS.jax_ipu_model_num_tiles = 8"
+    "# Uncomment to use IPU model emulator.\n",
+    "# config.FLAGS.jax_ipu_use_model = True\n",
+    "# config.FLAGS.jax_ipu_model_num_tiles = 8"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* Jax will automatically select `ipu` as default backend, the order is ipu > tpu > gpu > cpu."
+    "* JAX will automatically select `ipu` as default backend, the order is ipu > tpu > gpu > cpu."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Platform=ipu\n",
-      "Number ipus=1\n",
-      "[IpuDevice(id=0, tiles=8)]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-01-31 15:10:39.660557: W external/org_tensorflow/tensorflow/compiler/plugin/poplar/driver/poplar_executor.cc:1782] A version was not supplied when using the IPU Model. Defaulting to 'ipu2'.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import jax\n",
     "\n",
     "print(f\"Platform={jax.default_backend()}\")\n",
-    "print(f\"Number ipus={jax.device_count()}\")\n",
+    "print(f\"Number of devices={jax.device_count()}\")\n",
     "devices = jax.devices()\n",
     "print(devices)"
    ]
@@ -66,21 +64,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Result = [[ 1.486894    2.635103   -4.4571934 ]\n",
-      " [ 0.14053345 -1.1268771   0.8805641 ]\n",
-      " [-1.3035688  -1.5401895  -1.3022151 ]]\n",
-      "Platform = ipu\n",
-      "Device = ipu:0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "from jax import jit\n",
@@ -101,29 +87,18 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* With `jax.device_put` API, we can put variables to certain device. Here is an example to run jit function on `ipu:1`:"
+    "* With `jax.device_put` API, we can put variables to certain device. Here is an example to run jit function on `ipu:0`:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Result = [[ 1.486894    2.635103   -4.4571934 ]\n",
-      " [ 0.14053345 -1.1268771   0.8805641 ]\n",
-      " [-1.3035688  -1.5401895  -1.3022151 ]]\n",
-      "Platform = ipu\n",
-      "Device = ipu:0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "x = jax.device_put(x, devices[0])\n",
     "w = jax.device_put(w, devices[0])\n",
@@ -145,21 +120,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Result = [[ 1.4868938   2.635103   -4.4571934 ]\n",
-      " [ 0.14053339 -1.1268772   0.8805641 ]\n",
-      " [-1.3035688  -1.5401895  -1.3022151 ]]\n",
-      "Platform = cpu\n",
-      "Device = TFRT_CPU_0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from functools import partial\n",
     "\n",
@@ -174,6 +137,34 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### JAX Pseudo Random Numbers generation\n",
+    "\n",
+    "Reproducible random numbers across platforms using JAX ThreeFry PRNG."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def random_fn(seed: int):\n",
+    "    key = jax.random.PRNGKey(seed)\n",
+    "    k1, k2 = jax.random.split(key)\n",
+    "    return k2, jax.random.uniform(k1, (3,))\n",
+    "\n",
+    "random_fn_cpu = jax.jit(random_fn, backend=\"cpu\")\n",
+    "random_fn_ipu = jax.jit(random_fn, backend=\"ipu\")\n",
+    "\n",
+    "print(\"CPU PRNG:\", random_fn_cpu(42))\n",
+    "print(\"IPU PRNG:\", random_fn_ipu(42))"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -183,7 +174,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -201,7 +192,7 @@
   },
   "vscode": {
    "interpreter": {
-    "hash": "f152e18c2f3ad9f3fb65af9cd1c283092e7917e7680b23eef30b2e3db00ca13b"
+    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
    }
   }
  },

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Copyright (c) 2022 Graphcore Ltd. All rights reserved.
+# Script to be sourced on launch of the Gradient Notebook
+
+DETECTED_NUMBER_OF_IPUS=$(python .gradient/available_ipus.py)
+if [[ "$1" == "test" ]]; then
+    IPU_ARG="${DETECTED_NUMBER_OF_IPUS}"
+else
+    IPU_ARG=${1:-"${DETECTED_NUMBER_OF_IPUS}"}
+fi
+
+export NUM_AVAILABLE_IPU=${IPU_ARG}
+export GRAPHCORE_POD_TYPE="pod${IPU_ARG}"
+
+export POPLAR_EXECUTABLE_CACHE_DIR="/tmp/exe_cache"
+export DATASET_DIR="/tmp/dataset_cache"
+export CHECKPOINT_DIR="/tmp/checkpoints"
+
+# mounted public dataset directory (path in the container)
+# in the Paperspace environment this would be ="/datasets"
+export PUBLIC_DATASET_DIR="/datasets"
+
+export POPTORCH_CACHE_DIR="${POPLAR_EXECUTABLE_CACHE_DIR}"
+export POPTORCH_LOG_LEVEL=ERR
+export RDMAV_FORK_SAFE=1
+
+export PIP_DISABLE_PIP_VERSION_CHECK=1 CACHE_DIR=/tmp
+jupyter lab --allow-root --ip=0.0.0.0 --no-browser --ServerApp.trust_xheaders=True \
+            --ServerApp.disable_check_xsrf=False --ServerApp.allow_remote_access=True \
+            --ServerApp.allow_origin='*' --ServerApp.allow_credentials=True


### PR DESCRIPTION
  Small modifications to the repository and notebook to add Paperspace compatibility:
  * `setup.sh` script to setup Paperspace IPU instance;
  * `pip install` commands to install JAX for IPUs;
  * README link to Paperspace;
