### PR TITLE
Implement IPU ThreeFry algorithm custom vertex.

### DIFF
--- a/.github/workflows/jax-ipu-tests-internal.yaml
+++ b/.github/workflows/jax-ipu-tests-internal.yaml
@@ -74,7 +74,7 @@ jobs:
       # Run IPU specific unit tests
       - name: Run JAX IPU model unit tests
         run: |
-          JAX_IPU_DEVICE_COUNT=2 JAX_IPU_USE_MODEL=true JAX_IPU_MODEL_NUM_TILES=8 pytest --tb=short -vv --log-cli-level=INFO ./tests/ipu/
+          JAX_IPU_DEVICE_COUNT=2 JAX_IPU_USE_MODEL=true JAX_IPU_MODEL_NUM_TILES=16 pytest --tb=short -vv --log-cli-level=INFO ./tests/ipu/
       # Dockerized workflow known to create issues with self-hosted servers.
       # Solution is to fully cleanup the workspace for the next action.
       # See: https://stackoverflow.com/questions/70483902/how-to-actually-clean-up-the-repository-on-self-hosted-runner-after-github-actio

--- a/.github/workflows/jax-ipu-tests-public.yaml
+++ b/.github/workflows/jax-ipu-tests-public.yaml
@@ -68,7 +68,7 @@ jobs:
       # Run IPU specific unit tests
       - name: Run JAX IPU unit tests
         run: |
-          JAX_IPU_DEVICE_COUNT=2 JAX_IPU_USE_MODEL=true JAX_IPU_MODEL_NUM_TILES=8 pytest --tb=short -vv --log-cli-level=INFO ./tests/ipu/
+          JAX_IPU_DEVICE_COUNT=2 JAX_IPU_USE_MODEL=true JAX_IPU_MODEL_NUM_TILES=16 pytest --tb=short -vv --log-cli-level=INFO ./tests/ipu/
       # Dockerized workflow known to create issues with self-hosted servers.
       # Solution is to fully cleanup the workspace for the next action.
       # See: https://stackoverflow.com/questions/70483902/how-to-actually-clean-up-the-repository-on-self-hosted-runner-after-github-actio

--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -145,3 +145,6 @@ from jax import tree_util as tree_util
 from jax import util as util
 
 import jax.lib  # TODO(phawkins): remove this export.
+
+# Import IPU backend specific improvements/features.
+import jax.ipu

--- a/jax/ipu/random/__init__.py
+++ b/jax/ipu/random/__init__.py
@@ -11,5 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from . import primitive
-from . import random
+from . import prng

--- a/jax/ipu/random/ipu_random_primitive.py
+++ b/jax/ipu/random/ipu_random_primitive.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import cppimport
+import os
+from typing import Sequence
+
+from jax.interpreters import mlir
+from jax.interpreters.mlir import ir
+
+from jax.ipu.primitive import ipu_mlir_lowering_custom_primitive
+
+# Pybind11 extension import (and compilation if necessary).
+# Explicit path is more robust to different `pip install` usages.
+ext_filename = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "ipu_random_primitive_impl.cpp")
+)
+ipu_random_primitive_impl = cppimport.imp_from_filepath(
+    ext_filename, "jax.ipu.random.ipu_random_primitive_impl"
+)
+
+
+def ipu_threefry2x32_vertex_filename() -> str:
+  filename = "ipu_random_vertex.cpp"
+  return os.path.abspath(os.path.join(os.path.dirname(__file__), filename))
+
+
+def ipu_threefry2x32_lowering(
+    ctx: mlir.LoweringRuleContext, key0: ir.Value, key1: ir.Value, data0: ir.Value,
+    data1: ir.Value
+) -> Sequence[ir.Value]:
+  """`threefry2x32` algorithm IPU backend MLIR lowering, as a custom (optimized) Poplar primitive.
+
+  Args:
+    ctx: MLIR lowering context.
+    key0, key1: Key uint32 arrays.
+    data0, data1: Data uint32 arrays.
+  Returns:
+    ThreeFry 2x uint32 resulting arrays.
+  """
+  avals_in = ctx.avals_in
+  avals_out = ctx.avals_out
+  assert len(avals_in) == 4, avals_in
+  assert len(avals_out) == 2, avals_out
+
+  inputs = [key0, key1, data0, data1]
+  outputs = ipu_mlir_lowering_custom_primitive(
+      ipu_random_primitive_impl.IpuThreeFry2x32Primitive,
+      ctx,
+      inputs,
+      ipu_gp_filename=ipu_threefry2x32_vertex_filename()
+  )
+  return outputs

--- a/jax/ipu/random/ipu_random_primitive_impl.cpp
+++ b/jax/ipu/random/ipu_random_primitive_impl.cpp
@@ -1,0 +1,137 @@
+// cppimport
+// NOTE: comment necessary for automatic JIT compilation of the module.
+
+/* Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include <iostream>
+#include <ipu_custom_primitive.hpp>
+#include <poplar/Graph.hpp>
+#include <poputil/TileMapping.hpp>
+
+/**
+ * @brief IPU ThreeFry2x32 primitive implementation.
+ */
+class IpuThreeFry2x32Primitive : public jax::ipu::PrimitiveInterface {
+ public:
+  static jax::ipu::PrimitiveMetadata metadata(std::uint32_t num_inputs) {
+    return jax::ipu::PrimitiveMetadata{.num_inputs = num_inputs,
+                                       .is_elementwise = false,
+                                       .is_stateless = true,
+                                       .is_hashable = true,
+                                       .input_to_output_tensor_aliasing = {}};
+  }
+
+  static poplar::program::Program program(
+      poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs,
+      std::vector<poplar::Tensor>& outputs, const std::string& attributes,
+      const std::string& debug_prefix) {
+    if (inputs.size() != 4) {
+      throw poputil::poplibs_error(
+          "IPU ThreeFry primitive expecting 4 input tensors.");
+    }
+    const auto& target = graph.getTarget();
+    const auto num_tiles = target.getNumTiles();
+    const auto outshape = inputs[2].shape();
+    // Linear mapping for all inputs, to optimally fit ThreeFry sampling (and
+    // following unary ops).
+    const unsigned grainsize = 16;
+    const auto linear_mapping =
+        poputil::calcLinearTileMapping(graph, outshape, 1, grainsize);
+    graph.setTileMapping(inputs[0], linear_mapping);
+    graph.setTileMapping(inputs[1], linear_mapping);
+    graph.setTileMapping(inputs[2], linear_mapping);
+    graph.setTileMapping(inputs[3], linear_mapping);
+
+    // Flattening all inputs.
+    const auto& key0 = inputs[0].flatten();
+    const auto& key1 = inputs[1].flatten();
+    const auto& data0 = inputs[2].flatten();
+    const auto& data1 = inputs[3].flatten();
+
+    const auto debugContext = poplar::DebugContext("ipu_threefry2x32");
+    // Output tensors, per tile (following same tile mapping).
+    std::vector<poplar::Tensor> out0_list;
+    std::vector<poplar::Tensor> out1_list;
+    // Using data0 tile mapping as reference. May mean comms on key arrays.
+    const auto mapping0 = graph.getTileMapping(data0);
+    const auto cs = graph.addComputeSet(debugContext);
+
+    for (unsigned tile = 0; tile < num_tiles; tile++) {
+      // no data on this tile.
+      if (mapping0[tile].empty()) {
+        continue;
+      }
+      // Get contiguous regions we can pass to vertex.
+      const auto tileContiguousRegions =
+          graph.getSortedContiguousRegions(data0, mapping0[tile]);
+      if (tileContiguousRegions.size() == 0) {
+        continue;
+      }
+
+      for (const auto& regions : tileContiguousRegions) {
+        for (const auto& r : regions) {
+          const auto region_size = r.size();
+          // Corresponding output regions
+          auto out0_region = graph.addVariable(poplar::UNSIGNED_INT,
+                                               {region_size}, debugContext);
+          auto out1_region = graph.addVariable(poplar::UNSIGNED_INT,
+                                               {region_size}, debugContext);
+          graph.setTileMapping(out0_region, tile);
+          graph.setTileMapping(out1_region, tile);
+          out0_list.push_back(out0_region);
+          out1_list.push_back(out1_region);
+
+          // Call threefry custom vertex on the tile.
+          auto v = graph.addVertex(cs, "ThreeFry2x32Vertex",
+                                   {{"key0", key0.slice(r)},
+                                    {"key1", key1.slice(r)},
+                                    {"data0", data0.slice(r)},
+                                    {"data1", data1.slice(r)},
+                                    {"out0", out0_region},
+                                    {"out1", out1_region}});
+          graph.setTileMapping(v, tile);
+          // Empirical perf. estimate, measured on IPU hardware.
+          graph.setPerfEstimate(v, region_size * 130);
+        }
+      }
+    }
+    auto out0 = poplar::concat(out0_list).reshape(outshape);
+    auto out1 = poplar::concat(out1_list).reshape(outshape);
+    outputs.push_back(out0);
+    outputs.push_back(out1);
+    return poplar::program::Execute(cs, debugContext);
+  }
+};
+
+// Export the IPU JAX primitive in the shared library.
+EXPORT_IPU_JAX_PRIMITIVE(IpuThreeFry2x32Primitive);
+
+// Declare a pybind11, to provide easy compilation & import from Python.
+PYBIND11_MODULE(ipu_random_primitive_impl, m) {
+  pybind11::class_<IpuThreeFry2x32Primitive>(m, "IpuThreeFry2x32Primitive")
+      .def_static("metadata", &IpuThreeFry2x32Primitive::metadata,
+                  pybind11::arg("num_inputs"));
+}
+
+// cppimport configuration for compiling the pybind11 module.
+// clang-format off
+/*
+<%
+cfg['extra_compile_args'] = ['-std=c++17', '-fPIC', '-O2', '-Wall']
+cfg['libraries'] = ['poplar', 'poputil', 'poprand']
+cfg['include_dirs'] = []
+setup_pybind11(cfg)
+%>
+*/

--- a/jax/ipu/random/ipu_random_vertex.cpp
+++ b/jax/ipu/random/ipu_random_vertex.cpp
@@ -1,0 +1,116 @@
+/* Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include <poplar/HalfFloat.hpp>
+#include <poplar/Vertex.hpp>
+
+using namespace poplar;
+
+/**
+ * @brief ThreeFry algorithm IPU implementation.
+ *
+ * The interface is following the default XLA implementation in JAX.
+ */
+class ThreeFry2x32Vertex : public MultiVertex {
+ public:
+  using T = std::uint32_t;
+  // Pair of 32bit arrays used as keys.
+  Input<Vector<T, poplar::VectorLayout::ONE_PTR>> key0;
+  Input<Vector<T, poplar::VectorLayout::ONE_PTR>> key1;
+
+  // Pair of input data arrays.
+  Input<Vector<T, poplar::VectorLayout::SPAN>> data0;
+  Input<Vector<T, poplar::VectorLayout::SPAN>> data1;
+
+  // Output arrays, same shape as input data ones.
+  Output<Vector<T, poplar::VectorLayout::ONE_PTR>> out0;
+  Output<Vector<T, poplar::VectorLayout::ONE_PTR>> out1;
+
+  bool compute(unsigned wid) {
+    constexpr int num_workers = 6;
+    const int N = data0.size();
+    // Rotation distances specified by the Threefry2x32 algorithm.
+    std::uint32_t rotations[8] = {13, 15, 26, 6, 17, 29, 16, 24};
+
+    for (int idx = wid; idx < N; idx += num_workers) {
+      std::uint32_t x[2];
+      std::uint32_t ks[3];
+
+      // 0x1BD11BDA is a parity constant specified by the ThreeFry2x32
+      // algorithm.
+      ks[2] = 0x1BD11BDA;
+
+      ks[0] = key0[idx];
+      x[0] = data0[idx];
+      ks[2] = ks[2] ^ key0[idx];
+
+      ks[1] = key1[idx];
+      x[1] = data1[idx];
+      ks[2] = ks[2] ^ key1[idx];
+
+      auto rotate_left = [](std::uint32_t v, std::uint32_t distance) {
+        return (v << distance) | (v >> (32 - distance));
+      };
+
+      // Performs a single round of the Threefry2x32 algorithm, with a rotation
+      // amount 'rotation'.
+      auto round = [&](std::uint32_t* v, std::uint32_t rotation) {
+        v[0] += v[1];
+        v[1] = rotate_left(v[1], rotation);
+        v[1] ^= v[0];
+      };
+
+      // There are no known statistical flaws with 13 rounds of Threefry2x32.
+      // We are conservative and use 20 rounds.
+      x[0] = x[0] + ks[0];
+      x[1] = x[1] + ks[1];
+#pragma unroll
+      for (int i = 0; i < 4; ++i) {
+        round(x, rotations[i]);
+      }
+
+      x[0] = x[0] + ks[1];
+      x[1] = x[1] + ks[2] + 1u;
+#pragma unroll
+      for (int i = 4; i < 8; ++i) {
+        round(x, rotations[i]);
+      }
+
+      x[0] = x[0] + ks[2];
+      x[1] = x[1] + ks[0] + 2u;
+#pragma unroll
+      for (int i = 0; i < 4; ++i) {
+        round(x, rotations[i]);
+      }
+
+      x[0] = x[0] + ks[0];
+      x[1] = x[1] + ks[1] + 3u;
+#pragma unroll
+      for (int i = 4; i < 8; ++i) {
+        round(x, rotations[i]);
+      }
+
+      x[0] = x[0] + ks[1];
+      x[1] = x[1] + ks[2] + 4u;
+#pragma unroll
+      for (int i = 0; i < 4; ++i) {
+        round(x, rotations[i]);
+      }
+
+      out0[idx] = x[0] + ks[2];
+      out1[idx] = x[1] + ks[0] + 5u;
+    }
+    return true;
+  }
+};

--- a/jax/ipu/random/prng.py
+++ b/jax/ipu/random/prng.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from .ipu_random_primitive import ipu_threefry2x32_lowering
+
+from jax.interpreters import mlir
+from jax._src.lib.mlir.dialects import mhlo
+from jax._src.prng import threefry2x32_p
+
+
+def _ipu_threefry2x32_broadcast_lowering(ctx, k1, k2, x1, x2):
+  aval_out, _ = ctx.avals_out
+  k1_aval, k2_aval, x1_aval, x2_aval = ctx.avals_in
+  rank = len(aval_out.shape)
+  if 0 in aval_out.shape:
+    zeros = mlir.full_like_aval(0, aval_out)
+    return [zeros, zeros]
+
+  def _broadcast(x, aval):
+    return mhlo.BroadcastInDimOp(
+        mlir.aval_to_ir_type(aval_out), x,
+        mlir.dense_int_elements(range(rank - len(aval.shape), rank))
+    ).result
+
+  ctx = ctx.replace(avals_in=[aval_out] * 4)
+  # TODO: optimize in the case of scalar keys.
+  return ipu_threefry2x32_lowering(
+      ctx, _broadcast(k1, k1_aval), _broadcast(k2, k2_aval), _broadcast(x1, x1_aval),
+      _broadcast(x2, x2_aval)
+  )
+
+
+mlir.register_lowering(
+    threefry2x32_p, _ipu_threefry2x32_broadcast_lowering, platform="ipu"
+)


### PR DESCRIPTION
The default XLA lowering of ThreeFry algorithm is producing large (and inefficient) compute graphs. Fusing the former in a single IPU custom vertex will improve performance and compilation times when using JAX random sampling.