### PR TITLE
Basic support jax.debug.callback in JAX IPU experimental

### DIFF
--- a/ipu/docs/build.md
+++ b/ipu/docs/build.md
@@ -17,7 +17,10 @@ python build/build.py --enable_ipu --bazel_options=--override_repository=org_ten
 ```
 The `override_repository` config is optional. By default, the build process will pull the experimental IPU TensorFlow XLA code from the repository https://github.com/graphcore-research/tensorflow-jax-experimental.
 
-If the build is successful, a binary `jaxlib` Python wheel will be produced in the `dist/` directory.
+If the build is successful, a binary `jaxlib` Python wheel will be produced in the `dist/` directory:
+```bash
+ pip uninstall -y jaxlib && pip install ./dist/jaxlib*.whl
+```
 
 
 For testing purposes, it is also possible to produce a build with debug info:

--- a/jax/_src/debugging.py
+++ b/jax/_src/debugging.py
@@ -121,6 +121,8 @@ mlir.register_lowering(debug_callback_p, debug_callback_lowering,
                        platform="cpu")
 mlir.register_lowering(
     debug_callback_p, debug_callback_lowering, platform="gpu")
+mlir.register_lowering(
+    debug_callback_p, debug_callback_lowering, platform="ipu")
 if jaxlib.version >= (0, 3, 15):
   mlir.register_lowering(
       debug_callback_p, debug_callback_lowering, platform="tpu")

--- a/jax/ipu/debug/__init__.py
+++ b/jax/ipu/debug/__init__.py
@@ -11,6 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from . import primitive
-from . import debug
-from . import random
+from .ipu_python_callback import ipu_debug_callback_custom_call

--- a/jax/ipu/debug/ipu_python_callback.py
+++ b/jax/ipu/debug/ipu_python_callback.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import cppimport
+import os
+import json
+
+from jax.interpreters import mlir
+from jax.interpreters.mlir import ir
+from jax._src.lib.mlir.dialects import mhlo
+
+from jax.ipu.primitive.ipu_custom_primitive_utils import make_custom_primitive_attributes
+
+from jaxlib.ipu_xla_client import _ipu_xla
+
+# Pybind11 extension import (and compilation if necessary).
+# Explicit path is more robust to different `pip install` usages.
+ext_filename = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "ipu_python_callback_impl.cpp")
+)
+ipu_debug_callback_impl = cppimport.imp_from_filepath(
+    ext_filename, "jax.ipu.debug.ipu_python_callback_impl"
+)
+
+
+def ipu_debug_callback_custom_call(
+    ctx, result, operands_, *, has_side_effect: bool, callback_descriptor: int
+):
+  """IPU backend debug callback custom call.
+
+    This function is called inside `emit_python_callback` in JAX MLIR interpreter,
+    when the IPU XLA backend is used.
+    """
+  # Only supporting some specific configs!
+  if len(ctx.avals_out) > 0:
+    raise NotImplementedError(
+        "IPU backend only does not support outputs in host Python callbacks."
+    )
+  # Raw attributes: callback ptr + IPU XLA library filename.
+  opaque_attributes = ";".join([str(callback_descriptor), _ipu_xla.__file__])
+  # Custom op/primitive attributes.
+  opattributes = make_custom_primitive_attributes(
+      ipu_debug_callback_impl.IpuPythonCallbackPrimitive,
+      ctx.avals_out,
+      opaque_attributes=opaque_attributes,
+      ipu_gp_filename=None
+  )
+  # On HOST function => specific IPU XLA option.
+  opattributes["is_user_read_write"] = True
+  # IPU XLA backend custom op static name.
+  call_target_name = "UserOp"
+  # IPU XLA custom op expecting backend attributes encoded as json.
+  backend_config = json.dumps(opattributes)
+  result = mhlo.CustomCallOp(
+      result,
+      operands_,
+      call_target_name=ir.StringAttr.get(call_target_name),
+      has_side_effect=ir.BoolAttr.get(has_side_effect),
+      api_version=mlir.i32_attr(0),  # original CustomCall API.
+      called_computations=None,
+      backend_config=ir.StringAttr.get(backend_config),
+      operand_layouts=None,
+      result_layouts=None
+  )
+  return result

--- a/jax/ipu/debug/ipu_python_callback_impl.cpp
+++ b/jax/ipu/debug/ipu_python_callback_impl.cpp
@@ -1,0 +1,112 @@
+// cppimport
+// NOTE: comment necessary for automatic JIT compilation of the module.
+
+/* Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include <dlfcn.h>
+
+#include <cstdlib>
+#include <iostream>
+#include <ipu_custom_primitive.hpp>
+#include <sstream>
+
+struct XlaCustomCallStatus;
+/**
+ * Typedefs of XLA host callback functions exported in IPU XLA shared library.
+ */
+typedef void (*XlaPythonCpuCallbackType)(uint64_t callback_ptr, void* output,
+                                         void** inputs,
+                                         XlaCustomCallStatus* status);
+typedef XlaCustomCallStatus* (*XlaAllocateCustomCallStatusType)();
+typedef void (*XlaFreeCustomCallStatusType)(XlaCustomCallStatus* status);
+typedef const char* (*XlaGetErrorCustomCallStatusType)(
+    XlaCustomCallStatus* status);
+
+/**
+ * @brief IPU Python callback primitive implementation.
+ *
+ * Using host custom op mechanism in IPU XLA backend.
+ */
+class IpuPythonCallbackPrimitive : public jax::ipu::PrimitiveInterface {
+ public:
+  static jax::ipu::PrimitiveMetadata metadata(std::uint32_t num_inputs) {
+    return jax::ipu::PrimitiveMetadata{.num_inputs = num_inputs,
+                                       .is_elementwise = false,
+                                       .is_stateless = false,
+                                       .is_hashable = false,
+                                       .input_to_output_tensor_aliasing = {}};
+  }
+
+  static void hostCallback(const std::vector<const void*>& data,
+                           const std::vector<std::uint32_t>& number_of_elements,
+                           const std::vector<void*>& outputs,
+                           const std::string& attributes,
+                           const std::string& debugPrefix) {
+    static_assert(sizeof(uintptr_t) == sizeof(uint64_t),
+                  "Expected 64-bit pointers");
+    // Parse host callback metadata: callback pointer + library filename.
+    std::istringstream insstream(attributes);
+    std::string callback_ptr_str, library_filename;
+    std::getline(insstream, callback_ptr_str, ';');
+    std::getline(insstream, library_filename, ';');
+    const std::uint64_t callback_ptr = std::atol(callback_ptr_str.c_str());
+
+    // Opening IPU XLA extension library
+    // TODO: loading only once? Proper closing?
+    void* ipu_xla_extension_lib = dlopen(library_filename.c_str(), RTLD_LAZY);
+    // Get IPU callbacks methods.
+    const auto xla_allocate_status =
+        reinterpret_cast<XlaAllocateCustomCallStatusType>(
+            dlsym(ipu_xla_extension_lib, "IpuXlaAllocateCustomCallStatus"));
+    const auto xla_free_status = reinterpret_cast<XlaFreeCustomCallStatusType>(
+        dlsym(ipu_xla_extension_lib, "IpuXlaFreeCustomCallStatus"));
+    const auto xla_cpu_callback = reinterpret_cast<XlaPythonCpuCallbackType>(
+        dlsym(ipu_xla_extension_lib, "IpuXlaPythonCpuCallback"));
+    const auto xla_error_msg_status =
+        reinterpret_cast<XlaGetErrorCustomCallStatusType>(
+            dlsym(ipu_xla_extension_lib, "IpuXlaGetErrorCustomCallStatus"));
+
+    // Call XLA backend CPU callback, passing input data pointers.
+    auto status = xla_allocate_status();
+    void** inputs_ptr = (void**)(data.data());
+    xla_cpu_callback(callback_ptr, nullptr, inputs_ptr, status);
+    const char* call_error_msg = xla_error_msg_status(status);
+    if (call_error_msg != nullptr) {
+      std::cerr << "IPU host callback error. " << call_error_msg << std::endl;
+      throw pybind11::value_error(call_error_msg);
+    }
+    xla_free_status(status);
+  }
+};
+
+EXPORT_IPU_JAX_HOST_CALLBACK(IpuPythonCallbackPrimitive);
+
+// Declare a pybind11, to provide easy compilation & import from Python.
+PYBIND11_MODULE(ipu_python_callback_impl, m) {
+  pybind11::class_<IpuPythonCallbackPrimitive>(m, "IpuPythonCallbackPrimitive")
+      .def_static("metadata", &IpuPythonCallbackPrimitive::metadata,
+                  pybind11::arg("num_inputs"));
+}
+
+// cppimport configuration for compiling the pybind11 module.
+// clang-format off
+/*
+<%
+cfg['extra_compile_args'] = ['-std=c++17', '-fPIC', '-O2', '-Wall']
+cfg['libraries'] = ['poplar', 'poputil']
+cfg['include_dirs'] = []
+setup_pybind11(cfg)
+%>
+*/

--- a/jax/ipu/primitive/ipu_custom_primitive.hpp
+++ b/jax/ipu/primitive/ipu_custom_primitive.hpp
@@ -135,7 +135,7 @@ class PrimitiveInterface {
     is_stateless = metadata.is_stateless;                                     \
     is_hashable = metadata.is_hashable;                                       \
   }
-// Generate the main program C exported function `#opclsExport`.
+// Generate the IPU main program C exported function `#opclsExport`.
 #define IPU_JAX_PRIMITIVE_PROGRAM(opcls)                                     \
   extern "C" __attribute__((visibility("default"))) poplar::program::Program \
   CONCAT(opcls, Export)(                                                     \
@@ -143,6 +143,17 @@ class PrimitiveInterface {
       std::vector<poplar::Tensor>& outputs, const std::string& attributes,   \
       const std::string& debug_prefix) {                                     \
     return opcls::program(graph, inputs, outputs, attributes, debug_prefix); \
+  }
+// Generate the host callback C exported function `#opclsExport`.
+#define IPU_JAX_PRIMITIVE_HOST_CALLBACK(opcls)                             \
+  extern "C" __attribute__((visibility("default"))) void CONCAT(           \
+      opcls, Export)(const std::vector<const void*>& data,                 \
+                     const std::vector<std::uint32_t>& number_of_elements, \
+                     const std::vector<void*>& outputs,                    \
+                     const std::string& attributes,                        \
+                     const std::string& debugPrefix) {                     \
+    opcls::hostCallback(data, number_of_elements, outputs, attributes,     \
+                        debugPrefix);                                      \
   }
 // Generate the allocator C exported function `#opclsExport_allocator`.
 #define IPU_JAX_PRIMITIVE_ALLOCATOR(opcls)                                 \
@@ -158,6 +169,12 @@ class PrimitiveInterface {
 #define EXPORT_IPU_JAX_PRIMITIVE(opcls) \
   IPU_JAX_PRIMITIVE_METADATA(opcls);    \
   IPU_JAX_PRIMITIVE_PROGRAM(opcls);     \
+  IPU_JAX_PRIMITIVE_ALLOCATOR(opcls);
+
+// Export IPU JAX HOST callback as C functions in shared library.
+#define EXPORT_IPU_JAX_HOST_CALLBACK(opcls) \
+  IPU_JAX_PRIMITIVE_METADATA(opcls);        \
+  IPU_JAX_PRIMITIVE_HOST_CALLBACK(opcls);   \
   IPU_JAX_PRIMITIVE_ALLOCATOR(opcls);
 
 // Custom op API level default value.

--- a/tests/ipu/debug_test.py
+++ b/tests/ipu/debug_test.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2022 Graphcore Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from jax._src import test_util as jtu
+from functools import partial
+
+import numpy as np
+import jax
+
+from jax.config import config
+from jaxlib.ipu_xla_client import IpuPjRtDevice
+
+# Skipping tests on legacy IPU backend.
+is_ipu_legacy_backend = not isinstance(jax.devices("ipu")[0], IpuPjRtDevice)
+
+
+class IpuDebuggingTest(jtu.JaxTestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.is_ipu_model = config.FLAGS.jax_ipu_use_model
+
+  def test_host_debug_callback(self):
+    host_arrays = []
+
+    def host_callback(data):
+      host_arrays.append(data)
+
+    @partial(jax.jit, backend="ipu")
+    def fn(x):
+      x = 2 * x
+      jax.debug.callback(host_callback, x + 1)
+      return x + 2
+
+    data = np.array([1, 2, 3, 4], dtype=np.float32)
+
+    # FIXME: IPU PjRt client blocking if not using returned value.
+    out = fn(data)
+    out = fn(out)
+    out.block_until_ready()
+
+    assert len(host_arrays) == 2
+    assert all([isinstance(v, np.ndarray) for v in host_arrays])
+    self.assertAllClose(out, 4 * data + 6)
+    self.assertAllClose(host_arrays[0], 2 * data + 1)
+    self.assertAllClose(host_arrays[1], 4 * data + 5)


### PR DESCRIPTION
Using an IPU XLA host custom op to provide a custom MLIR lowering
for `debug_callback_p` JAX primitive.

The implementation is mostly re-using the XLA CPU callback logic, once
data have been streamed back to the HOST.